### PR TITLE
drop_units earlier to safely use cbind

### DIFF
--- a/R/calc_eco_variables.R
+++ b/R/calc_eco_variables.R
@@ -61,9 +61,9 @@ rangeSize <- function(coords, crs = 'epsg:4326'){
     # duplicate points (multiple taxa per site) don't affect centroid
     cntr <- unlist( sf::st_centroid(ptsGrp) )
     gcdists <- sf::st_distance(sfPts) # returns units-class object
-    gcdists <- units::set_units(gcdists, 'km')
+    gcdists <- units::drop_units(units::set_units(gcdists, 'km'))
     gcMax <- max(gcdists)
-    mst <- vegan::spantree( units::drop_units(gcdists) )
+    mst <- vegan::spantree(gcdists)
     agg <- sum(mst$dist)
     diag(gcdists) <- NA
     mpd <- mean(gcdists, na.rm = TRUE)


### PR DESCRIPTION
Dear maintainer,

We are preparing units 0.8-6 for release. I'm writing to you because our revdep checks report new issues in your package with this new version (you can check them [here](https://github.com/r-quantities/units/blob/main/revdep/problems.md#divvy)).

These issues are caused by the recent addition of the `cbind.units` and `rbind.units` methods. Binding a mix of units and non-units objects won't work anymore. So it's important to properly add/drop units for all objects involved. This simple patch ensures that units are dropped after converting to km, so that the subsequent `cbind` call works as expected.

We would appreciate if you could merge this patch and send an update to CRAN as time permits.